### PR TITLE
fix missing xlink namespace prefix

### DIFF
--- a/svg-innerhtml.js
+++ b/svg-innerhtml.js
@@ -67,7 +67,7 @@
         var dXML = new DOMParser();
         dXML.async = false;
         // Wrap the markup into a SVG node to ensure parsing works.
-        sXML = '<svg xmlns=\'http://www.w3.org/2000/svg\'>' + markupText + '</svg>';
+        sXML = '<svg xmlns=\'http://www.w3.org/2000/svg\' xmlns:xlink=\'http://www.w3.org/1999/xlink\'>' + markupText + '</svg>';
         var svgDocElement = dXML.parseFromString(sXML, 'text/xml').documentElement;
 
         // Now take each node, import it and append to this element.


### PR DESCRIPTION
Avoid error in IE 11 when you refer to a symbol in a use statement with
"xlink:href" attribute:
Error: Error parsing XML string
XML5660: The specified prefix has not been declared.